### PR TITLE
Move from sisu-guice to guice 4.1 and fix related changes

### DIFF
--- a/extensions/closeable/pom.xml
+++ b/extensions/closeable/pom.xml
@@ -52,8 +52,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.sonatype.sisu</groupId>
-            <artifactId>sisu-guice</artifactId>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/extensions/injection/pom.xml
+++ b/extensions/injection/pom.xml
@@ -52,8 +52,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.sonatype.sisu</groupId>
-            <artifactId>sisu-guice</artifactId>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/extensions/injection/src/main/java/com/mycila/guice/ext/injection/MBinder.java
+++ b/extensions/injection/src/main/java/com/mycila/guice/ext/injection/MBinder.java
@@ -21,14 +21,15 @@ import com.google.inject.binder.AnnotatedConstantBindingBuilder;
 import com.google.inject.binder.LinkedBindingBuilder;
 import com.google.inject.matcher.Matcher;
 import com.google.inject.matcher.Matchers;
+import com.google.inject.spi.Dependency;
 import com.google.inject.spi.Message;
+import com.google.inject.spi.ModuleAnnotatedMethodScanner;
 import com.google.inject.spi.ProvisionListener;
 import com.google.inject.spi.TypeConverter;
 import com.google.inject.spi.TypeListener;
-import org.aopalliance.intercept.MethodInterceptor;
-
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
+import org.aopalliance.intercept.MethodInterceptor;
 
 /**
  * @author Mathieu Carbou (mathieu.carbou@gmail.com)
@@ -210,4 +211,15 @@ public class MBinder implements Binder {
     public void requireExactBindingAnnotations() {
         binder.requireExactBindingAnnotations();
     }
+
+    @Override
+    public <T> Provider<T> getProvider(Dependency<T> dpndnc) {
+        return binder.getProvider(dpndnc);
+    }
+
+    @Override
+    public void scanModulesForAnnotatedMethods(ModuleAnnotatedMethodScanner mams) {
+        binder.scanModulesForAnnotatedMethods(mams);
+    }
+
 }

--- a/extensions/injection/src/main/java/com/mycila/guice/ext/injection/MethodInvoker.java
+++ b/extensions/injection/src/main/java/com/mycila/guice/ext/injection/MethodInvoker.java
@@ -21,7 +21,6 @@ import com.google.common.cache.LoadingCache;
 import com.google.inject.internal.BytecodeGen;
 import com.google.inject.internal.cglib.core.$CodeGenerationException;
 import com.google.inject.internal.cglib.reflect.$FastMethod;
-
 import java.lang.annotation.Annotation;
 import java.lang.reflect.*;
 import java.util.concurrent.ExecutionException;
@@ -39,7 +38,7 @@ public class MethodInvoker implements Member, AnnotatedElement {
                 int modifiers = method.getModifiers();
                 if (!Modifier.isPrivate(modifiers) && !Modifier.isProtected(modifiers)) {
                     try {
-                        final $FastMethod fastMethod = BytecodeGen.newFastClass(method.getDeclaringClass(), BytecodeGen.Visibility.forMember(method)).getMethod(method);
+                        final $FastMethod fastMethod = BytecodeGen.newFastClassForMember(method.getDeclaringClass(), method).getMethod(method);
                         return new MethodInvoker(method) {
                             @Override
                             public Object invoke(Object target, Object... parameters) {

--- a/extensions/service/pom.xml
+++ b/extensions/service/pom.xml
@@ -52,8 +52,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.sonatype.sisu</groupId>
-            <artifactId>sisu-guice</artifactId>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/extensions/web/pom.xml
+++ b/extensions/web/pom.xml
@@ -66,7 +66,7 @@
 
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <url>http://mycila.github.io/${mycila.github.name}</url>
 
     <properties>
-        <jdk.version>1.6</jdk.version>
+        <jdk.version>1.7</jdk.version>
         <mycila.github.name>guice</mycila.github.name>
     </properties>
 
@@ -98,9 +98,9 @@
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.sonatype.sisu</groupId>
-                <artifactId>sisu-guice</artifactId>
-                <version>3.2.3</version>
+                <groupId>com.google.inject</groupId>
+                <artifactId>guice</artifactId>
+                <version>4.1.0</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.sonatype.sisu</groupId>
@@ -111,7 +111,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>18.0</version>
+                <version>19.0</version>
                 <exclusions>
                     <exclusion>
                         <groupId>com.google.code.findbugs</groupId>
@@ -122,17 +122,17 @@
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit-dep</artifactId>
-                <version>4.10</version>
+                <version>4.11</version>
             </dependency>
             <dependency>
                 <groupId>javax.servlet</groupId>
-                <artifactId>servlet-api</artifactId>
-                <version>3.0-alpha-1</version>
+                <artifactId>javax.servlet-api</artifactId>
+                <version>3.1.0</version>
             </dependency>
             <dependency>
                 <groupId>org.codehaus.groovy</groupId>
                 <artifactId>groovy-all</artifactId>
-                <version>2.1.6</version>
+                <version>2.4.7</version>
             </dependency>
             <dependency>
                 <groupId>com.ovea.tajin.servers</groupId>

--- a/servlet/pom.xml
+++ b/servlet/pom.xml
@@ -54,8 +54,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.sonatype.sisu</groupId>
-            <artifactId>sisu-guice</artifactId>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
@@ -64,7 +64,7 @@
 
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
Since Google Guice doesn't support - and want to support - JSR250 lifecycles, I was using mycila/guice to fill the gap. Google Guice 4.1 introduced some breaking changes and I tried to fix the one line necessary which also made me change the dependencies from sisu-guice to google-guice.
